### PR TITLE
html-webpack-plugin 版本升级为  4.0.0-beta.8

### DIFF
--- a/packages/ucf-scripts/package.json
+++ b/packages/ucf-scripts/package.json
@@ -49,7 +49,7 @@
     "fs-extra": "8.0.1",
     "get-port": "5.0.0",
     "glob": "7.1.4",
-    "html-webpack-plugin": "3.2.0",
+    "html-webpack-plugin": "4.0.0-beta.8",
     "http-proxy-middleware": "0.19.1",
     "ip": "1.1.5",
     "less": "3.9.0",


### PR DESCRIPTION
解决使用多个 html-webpack-plugin 后编译慢的问题。详见 https://github.com/jantimon/html-webpack-plugin/issues/724#issuecomment-419885840